### PR TITLE
Update plugins.md with semver range support specification

### DIFF
--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -256,7 +256,7 @@ A plugin can explicitly specify compatibility with a specific OpenSearch version
 ```bash
 opensearch.version=2.3.0
 ```
-Alternately, a plugin can specify a range of compatible OpenSearch versions using the 'dependencies' property in its plugin-descriptor.properties file. Following notations are supported:
+Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file in one of the following notations:
 - `dependencies={ opensearch: "2.3.0" }`
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "=2.3.0" }`

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -261,7 +261,7 @@ Alternatively, a plugin can specify a range of compatible OpenSearch versions by
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "=2.3.0" }`
   Plugin is compatible only with OpenSearch version 2.3.0.
-- `dependencies={ opensearch: "~2.3.0" }`
+- `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).
   Plugin is compatible with all versions starting from 2.3.0 upto next minor version, i.e. 2.4.0 (exclusive).
 - `dependencies={ opensearch: "^2.3.0" }`
   Plugin is compatible with all versions starting from 2.3.0 upto next major version, i.e. 3.0.0 (exclusive).

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -256,7 +256,7 @@ A plugin can explicitly specify compatibility with a specific OpenSearch version
 ```properties
 opensearch.version=2.3.0
 ```
-Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file in one of the following notations:
+Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file using one of the following notations:
 - `dependencies={ opensearch: "2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "=2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -263,7 +263,6 @@ Alternatively, a plugin can specify a range of compatible OpenSearch versions by
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).
 - `dependencies={ opensearch: "^2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next major version, in this example, 3.0.0 (exclusive).
-  Plugin is compatible with all versions starting from 2.3.0 upto next major version, i.e. 3.0.0 (exclusive).
 
 You can only specify one of `opensearch.version` or `dependencies` properties.
 {: .note}

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -253,7 +253,7 @@ OpenSearch provides several bundled plugins and additional plugins.
 
 A plugin can explicitly specify compatibility with a specific OpenSearch version by listing that version in its `plugin-descriptor.properties` file. For example, a plugin with the following property is compatible only with OpenSearch 2.3.0:
 
-```bash
+```properties
 opensearch.version=2.3.0
 ```
 Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file in one of the following notations:

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -262,7 +262,7 @@ Alternatively, a plugin can specify a range of compatible OpenSearch versions by
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).
 - `dependencies={ opensearch: "^2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next major version, in this example, 3.0.0 (exclusive).
 
-You can only specify one of `opensearch.version` or `dependencies` properties.
+You can specify only one of the `opensearch.version` or `dependencies` properties.
 {: .note}
 
 ### Bundled plugins

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -247,8 +247,24 @@ bin/opensearch-plugin install --batch <plugin-name>
 
 ## Available plugins
 
-Major, minor, and patch plugin versions must match OpenSearch major, minor, and patch versions in order to be compatible. For example, plugins versions 2.3.0.x work only with OpenSearch 2.3.0.
-{: .warning}
+### Plugin Compatibility
+
+A plugin can specify explicit compatibility with a specific OpenSearch version. For example, a plugin with following property in its plugin-descriptor.properties is compatible only with OpenSearch 2.3.0
+```bash
+opensearch.version=2.3.0
+```
+Alternately, a plugin can specify a range of compatible OpenSearch versions using the 'dependencies' property in its plugin-descriptor.properties file. Following notations are supported:
+- `dependencies={ opensearch: "2.3.0" }`
+  Plugin is compatible only with OpenSearch version 2.3.0.
+- `dependencies={ opensearch: "=2.3.0" }`
+  Plugin is compatible only with OpenSearch version 2.3.0.
+- `dependencies={ opensearch: "~2.3.0" }`
+  Plugin is compatible with all versions starting from 2.3.0 upto next minor version, i.e. 2.4.0 (exclusive).
+- `dependencies={ opensearch: "^2.3.0" }`
+  Plugin is compatible with all versions starting from 2.3.0 upto next major version, i.e. 3.0.0 (exclusive).
+
+Only one of `opensearch.version` or `dependencies` properties is allowed to be specified.
+{: .note}
 
 ### Bundled plugins
 

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -259,7 +259,6 @@ opensearch.version=2.3.0
 Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file in one of the following notations:
 - `dependencies={ opensearch: "2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "=2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
-  Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).
 - `dependencies={ opensearch: "^2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next major version, in this example, 3.0.0 (exclusive).
 

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -247,7 +247,7 @@ bin/opensearch-plugin install --batch <plugin-name>
 
 ## Available plugins
 
-OpenSearch provides several bundled plugins and additional plugins.
+OpenSearch provides several bundled and additional plugins.
 
 ### Plugin compatibility
 

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -258,7 +258,7 @@ opensearch.version=2.3.0
 ```
 Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file in one of the following notations:
 - `dependencies={ opensearch: "2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
-- `dependencies={ opensearch: "=2.3.0" }`
+- `dependencies={ opensearch: "=2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).
 - `dependencies={ opensearch: "^2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next major version, in this example, 3.0.0 (exclusive).

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -257,7 +257,7 @@ A plugin can explicitly specify compatibility with a specific OpenSearch version
 opensearch.version=2.3.0
 ```
 Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file in one of the following notations:
-- `dependencies={ opensearch: "2.3.0" }`
+- `dependencies={ opensearch: "2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "=2.3.0" }`
   Plugin is compatible only with OpenSearch version 2.3.0.

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -266,7 +266,7 @@ Alternatively, a plugin can specify a range of compatible OpenSearch versions by
 - `dependencies={ opensearch: "^2.3.0" }`
   Plugin is compatible with all versions starting from 2.3.0 upto next major version, i.e. 3.0.0 (exclusive).
 
-Only one of `opensearch.version` or `dependencies` properties is allowed to be specified.
+You can only specify one of `opensearch.version` or `dependencies` properties.
 {: .note}
 
 ### Bundled plugins

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -251,7 +251,8 @@ OpenSearch provides several bundled plugins and additional plugins.
 
 ### Plugin compatibility
 
-A plugin can specify explicit compatibility with a specific OpenSearch version. For example, a plugin with following property in its plugin-descriptor.properties is compatible only with OpenSearch 2.3.0
+A plugin can explicitly specify compatibility with a specific OpenSearch version by listing that version in its `plugin-descriptor.properties` file. For example, a plugin with the following property is compatible only with OpenSearch 2.3.0:
+
 ```bash
 opensearch.version=2.3.0
 ```

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -262,7 +262,6 @@ Alternatively, a plugin can specify a range of compatible OpenSearch versions by
 - `dependencies={ opensearch: "=2.3.0" }`
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).
-  Plugin is compatible with all versions starting from 2.3.0 upto next minor version, i.e. 2.4.0 (exclusive).
 - `dependencies={ opensearch: "^2.3.0" }`
   Plugin is compatible with all versions starting from 2.3.0 upto next major version, i.e. 3.0.0 (exclusive).
 

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -258,7 +258,6 @@ opensearch.version=2.3.0
 ```
 Alternatively, a plugin can specify a range of compatible OpenSearch versions by setting the `dependencies` property in its `plugin-descriptor.properties` file in one of the following notations:
 - `dependencies={ opensearch: "2.3.0" }`: The plugin is compatible only with OpenSearch version 2.3.0.
-  Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "=2.3.0" }`
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -262,7 +262,7 @@ Alternatively, a plugin can specify a range of compatible OpenSearch versions by
 - `dependencies={ opensearch: "=2.3.0" }`
   Plugin is compatible only with OpenSearch version 2.3.0.
 - `dependencies={ opensearch: "~2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next minor version, in this example, 2.4.0 (exclusive).
-- `dependencies={ opensearch: "^2.3.0" }`
+- `dependencies={ opensearch: "^2.3.0" }`: The plugin is compatible with all versions starting from 2.3.0 up to the next major version, in this example, 3.0.0 (exclusive).
   Plugin is compatible with all versions starting from 2.3.0 upto next major version, i.e. 3.0.0 (exclusive).
 
 You can only specify one of `opensearch.version` or `dependencies` properties.

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -247,7 +247,9 @@ bin/opensearch-plugin install --batch <plugin-name>
 
 ## Available plugins
 
-### Plugin Compatibility
+OpenSearch provides several bundled plugins and additional plugins.
+
+### Plugin compatibility
 
 A plugin can specify explicit compatibility with a specific OpenSearch version. For example, a plugin with following property in its plugin-descriptor.properties is compatible only with OpenSearch 2.3.0
 ```bash


### PR DESCRIPTION
Add support for specifying 'dependencies' for a plugin in its plugin-descriptor.properties file. This property allows for specification of a range of OpenSearch versions for plugin compatibility check.

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/6433


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
